### PR TITLE
Fix backslash in string (#6)

### DIFF
--- a/lslforge/haskell/src/Language/Lsl/Parse.hs
+++ b/lslforge/haskell/src/Language/Lsl/Parse.hs
@@ -239,7 +239,7 @@ stringLiteral   = lexeme (
 stringChar :: CharParser st (Maybe Char)
 stringChar = do{ c <- stringLetter; return (Just c) }
          <|> try stringEscape
-         <|> (char '\\' >> return (Just '\\'))
+         <|> (char '\\' >> return Nothing)
          <?> "string character"
                 
 stringLetter = satisfy (\c -> (c /= '"') && (c /= '\\') && (c > '\026'))


### PR DESCRIPTION
I tested script bellow:
```
string bad_string	= "/\/\onies!";

default {
    state_entry() {
        llOwnerSay(bad_string + "\;\t\\\"\n");
    }
}

```
It was compiled to:
```
// RaySilent.Issue#6.lslp 
// 2016-11-13 01:49:34 - LSLForge (0.1.9) generated
string bad_string = "//onies!";

default {

    state_entry() {
    llOwnerSay((bad_string + ";\t\\\"\n"));
  }
}

```