### PR TITLE
Fix multiline string bug (#26)

### DIFF
--- a/lslforge/haskell/src/Language/Lsl/Parse.hs
+++ b/lslforge/haskell/src/Language/Lsl/Parse.hs
@@ -242,7 +242,7 @@ stringChar = do{ c <- stringLetter; return (Just c) }
          <|> (char '\\' >> return (Just '\\'))
          <?> "string character"
                 
-stringLetter = satisfy (\c -> (c /= '"') && (c /= '\\') && (c > '\026'))
+stringLetter = satisfy (\c -> (c /= '"') && (c /= '\\'))
 
 stringEscape = do
     char '\\'


### PR DESCRIPTION
```
string gString0 = "I scream,\nyou scream,\nwe all scream,\nfor ice-cream!";
string gString1 = "I scream,
you scream,
we all scream,
for ice-cream!";

default
{
    state_entry()
    {
        if ( gString0 == gString1 )
            llOwnerSay("same");
        else
            llOwnerSay("not same");
    }
}
```
compiled to:
```
// RaySilent.Issue#26_multilinestring.lslp 
// 2016-11-13 02:32:20 - LSLForge (0.1.9) generated
string gString0 = "I scream,\nyou scream,\nwe all scream,\nfor ice-cream!";
string gString1 = "I scream,\nyou scream,\nwe all scream,\nfor ice-cream!";

default {

    state_entry() {
    if ((gString0 == gString1)) llOwnerSay("same");
    else  llOwnerSay("not same");
  }
}

```