### PR TITLE
Pell smit/0.1.9.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ lslforge/eclipse/lslforge-linux-x86/os/linux/x86/LSLForge
 lslforge/eclipse/lslforge-linux-x86_64/os/linux/x86_64/LSLForge
 lslforge/eclipse/lslforge-win32-x86/os/win32/x86/LSLForge.exe
 /lslforge/eclipse/lslforge-macosx-x86/os/macosx/x86/LSLForge
+lslforge/eclipse/lslforge-macosx-x86_64/os/macosx/x86_64/LSLForge
 
 #Newfie's ad-hoc build scripts
 lslforge/build_*

--- a/lslforge/codegen_mac.sh
+++ b/lslforge/codegen_mac.sh
@@ -1,0 +1,3 @@
+rm -v eclipse/lslforge/src/lslforge/generated/*.java
+
+eclipse/lslforge-macos-x86_64/os/macos/x86_64/LSLForge _CodeGen_ eclipse/lslforge/src/lslforge/generated lslforge.generated

--- a/lslforge/copy_mac.sh
+++ b/lslforge/copy_mac.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-strip haskell/dist/build/LSLForge/LSLForge
-cp haskell/dist/build/LSLForge/LSLForge eclipse/lslforge-macosx-x86/os/macosx/x86
+strip haskell/.stack-work/install/x86_64-osx/lts-8.2/8.0.2/bin/LSLForge
+cp haskell/.stack-work/install/x86_64-osx/lts-8.2/8.0.2/bin/LSLForge eclipse/lslforge-macos-x86_64/os/macos/x86_64

--- a/lslforge/haskell/LSLForge.cabal
+++ b/lslforge/haskell/LSLForge.cabal
@@ -42,6 +42,7 @@ executable LSLForge
   main-is:        LslForge.hs
   hs-source-dirs: src
   other-modules:
+    Control.Monad.Outdated.Error
     Data.Generics.Extras.Schemes
     Data.LabelExtras
     Language.Lsl.Internal.AccessGenerator

--- a/lslforge/haskell/src/Control/Monad/Outdated/Error.hs
+++ b/lslforge/haskell/src/Control/Monad/Outdated/Error.hs
@@ -1,0 +1,42 @@
+-- We encountered problem that LSLForge process hung up when start up.
+-- I knew it was caused by difference of 'fail' for Either monad behavier
+-- between base version prior 4.3 and later.
+-- Prior 4.3, fail returns Left e, but later throws exception.
+-- Language.Lsl.Internal.Util.lookupM is called in 3 monads,
+-- Maybe, Either and WorldE, using to search various things.
+-- In a case to search module name from library list given by Eclipse,
+-- lookupM calls fail when module name not found,
+-- it's ok on GHC 6.10.4 because it same to Left,
+-- but GHC using base 4.3 or later (including 8.0.2) throws exception
+-- and cause LSLForge process to error-exit.
+-- I copied Error class from GHC library
+-- to reproduce old 'fail' method. By Pell Smit
+
+module Control.Monad.Outdated.Error (
+    Error(..),
+    ErrorList(..)
+  ) where
+
+import Control.Monad.Fail(MonadFail(..))
+
+-- This class was copied from Control.Monad.Trans.Error
+-- which will be removed from standard library.
+-- But we still need this class for fail on Either monad.
+class Error e where
+    noMsg  :: e
+    noMsg    = strMsg ""
+    strMsg :: String -> e
+    strMsg _ = noMsg
+
+instance ErrorList a => Error [a] where
+    strMsg = listMsg
+
+class ErrorList a where
+    listMsg :: String -> [a]
+
+instance ErrorList Char where
+    listMsg = id
+
+-- This is core to reproduce old Either fail.
+instance Error e => MonadFail (Either e) where
+    fail s = Left $ strMsg s

--- a/lslforge/haskell/src/Language/Lsl/Internal/AvEvents.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/AvEvents.hs
@@ -2,17 +2,18 @@ module Language.Lsl.Internal.AvEvents(AvatarOutputEvent(..),
                     AvatarInputEvent(..)) where
 
 import Language.Lsl.Internal.Key(LSLKey(..))
+import Language.Lsl.Internal.Util(LSLInteger)
 
 data AvatarOutputEvent =
       AvatarTouch { avatarTouchPrimKey :: LSLKey, avatarTouchDuration :: Float }
-    | AvatarWhisper { avatarChatChannel :: Int, avatarChatMessage :: String }
-    | AvatarSay { avatarChatChannel :: Int, avatarChatMessage :: String }
-    | AvatarShout { avatarChatChannel :: Int, avatarChatMessage :: String }
-    | AvatarPay { avatarPayPrimKey :: LSLKey, avatarPayAmount :: Int }
-    | AvatarControl { avatarNewControlBits :: Int }
+    | AvatarWhisper { avatarChatChannel :: LSLInteger, avatarChatMessage :: String }
+    | AvatarSay { avatarChatChannel :: LSLInteger, avatarChatMessage :: String }
+    | AvatarShout { avatarChatChannel :: LSLInteger, avatarChatMessage :: String }
+    | AvatarPay { avatarPayPrimKey :: LSLKey, avatarPayAmount :: LSLInteger }
+    | AvatarControl { avatarNewControlBits :: LSLInteger }
     | AvatarFaceTouch { avatarTouchPrimKey :: LSLKey,
                         avatarTouchDuration :: Float,
-                        avatarTouchFace :: Int,
+                        avatarTouchFace :: LSLInteger,
                         avatarTouchST :: (Float,Float) }
     | AvatarHTTPRequest { avatarHTTPRequestURL :: String,
                           avatarHTTPRequestMethod :: String,
@@ -25,10 +26,10 @@ data AvatarInputEvent =
       AvatarOwnerSay { avatarOwnerSayPrimKey :: LSLKey, avatarOwnerSayMsg :: String }
     | AvatarHearsChat { avatarHearsChatFromName :: String, avatarHearsChatFromKey :: LSLKey, avatarHearsChatMsg :: String }
     | AvatarDialog { avatarDialogMessage :: String, avatarDialogButtons :: [String],
-                          avatarDialogChannel :: Int, avatarDialogSourceObject :: LSLKey }
+                          avatarDialogChannel :: LSLInteger, avatarDialogSourceObject :: LSLKey }
     | AvatarLoadURL { avatarLoadURLMessage :: String, avatarLoadURLAddress :: String }
     | AvatarMapDestination { avatarMapDestination :: String, avatarMapDestinationPosition :: (Float,Float,Float) }
-    | AvatarHTTPResponse { avatarHTTPResponseKey :: LSLKey, avatarHTTPResponseStatus :: Int,
+    | AvatarHTTPResponse { avatarHTTPResponseKey :: LSLKey, avatarHTTPResponseStatus :: LSLInteger,
         avatarHTTPResponseBody :: String }
     | AvatarHTTPRequestKey { avatarHTTPResponseKey :: LSLKey }
     | AvatarHTTPBadRequest

--- a/lslforge/haskell/src/Language/Lsl/Internal/CompilationServer.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/CompilationServer.hs
@@ -16,7 +16,7 @@ import Language.Lsl.Internal.Util
 import qualified Language.Lsl.Internal.XmlCreate as E
 import Language.Lsl.Internal.SerializationGenerator
 import Language.Lsl.Internal.DOMCombinators
-import Language.Lsl.Internal.SerializationInstances(jrep'Maybe,jrep'Either)
+import Language.Lsl.Internal.SerializationInstances(jrep'Maybe,jrep'Either,jrep'Tuple2,jrep'Tuple3)
 import System.Directory
 import System.FilePath(replaceExtension)
 

--- a/lslforge/haskell/src/Language/Lsl/Internal/Constants.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/Constants.hs
@@ -5,6 +5,7 @@ import Data.Bits((.|.),shiftL)
 import Data.Foldable(find)
 import Language.Lsl.Internal.Key(LSLKey(..))
 import Language.Lsl.Internal.Type(LSLType,LSLValue(..),typeOfLSLValue)
+import Language.Lsl.Internal.Util(LSLInteger)
 
 data Constant a = Constant { constName :: String, constVal :: LSLValue a }
     deriving (Show)
@@ -21,15 +22,15 @@ cInventoryObject = 6;llcInventoryObject :: RealFloat a => LSLValue a; llcInvento
 cInventoryScript = 10;llcInventoryScript :: RealFloat a => LSLValue a; llcInventoryScript = IVal cInventoryScript
 cInventorySound = 1;llcInventorySound :: RealFloat a => LSLValue a; llcInventorySound = IVal cInventorySound
 cInventoryTexture = 0;llcInventoryTexture :: RealFloat a => LSLValue a; llcInventoryTexture = IVal cInventoryTexture
-cPermissionChangeLinks = 0x80 :: Int
+cPermissionChangeLinks = 0x80 :: LSLInteger
 llcPermissionChangeLinks = IVal cPermissionChangeLinks
 
-cChangedLink = 0x20 :: Int
+cChangedLink = 0x20 :: LSLInteger
 llcChangedLink = IVal cChangedLink
 cChangedInventory = 0x1;llcChangedInventory :: RealFloat a => LSLValue a; llcChangedInventory = IVal cChangedInventory
 cChangedAllowedDrop = 0x40;llcChangedAllowedDrop :: RealFloat a => LSLValue a; llcChangedAllowedDrop = IVal cChangedAllowedDrop
 
-cChangedRegionStart = 0x400 :: Int
+cChangedRegionStart = 0x400 :: LSLInteger
 llcChangedRegionStart = IVal cChangedRegionStart
 
 cMaskBase = 0;llcMaskBase :: RealFloat a => LSLValue a; llcMaskBase = IVal cMaskBase
@@ -53,15 +54,15 @@ cPrimTypeSculpt = 7;llcPrimTypeSculpt :: RealFloat a => LSLValue a; llcPrimTypeS
 cPrimTypeTorus = 4;llcPrimTypeTorus :: RealFloat a => LSLValue a; llcPrimTypeTorus = IVal cPrimTypeTorus
 cPrimTypeTube = 5;llcPrimTypeTube :: RealFloat a => LSLValue a; llcPrimTypeTube = IVal cPrimTypeTube
 
-validAttachmentPoints = [0..36]::[Int]
+validAttachmentPoints = [0..36]::[LSLInteger]
 
-cDebugChannel = 2147483647 :: Int
+cDebugChannel = 2147483647 :: LSLInteger
 llcDebugChannel = IVal cDebugChannel
 
 cEOF = "\n\n\n"
 llcEOF = (SVal cEOF)
 
-cPermissionControlCamera = 0x800 :: Int
+cPermissionControlCamera = 0x800 :: LSLInteger
 llcPermissionControlCamera = IVal cPermissionControlCamera
 cPermissionTrackCamera = 0x400;llcPermissionTrackCamera :: RealFloat a => LSLValue a; llcPermissionTrackCamera = IVal cPermissionTrackCamera
 cPermissionTriggerAnimation = 0x10;llcPermissionTriggerAnimation :: RealFloat a => LSLValue a; llcPermissionTriggerAnimation = IVal cPermissionTriggerAnimation
@@ -142,13 +143,13 @@ cRemoteDataReply = 3;llcRemoteDataReply :: RealFloat a => LSLValue a; llcRemoteD
 llcZeroVector = VVal 0 0 0
 llcZeroRotation = RVal 0 0 0 1
 
-mkIConst :: RealFloat a => Int -> (Int,LSLValue a)
-mkIConst i = (i,IVal i)
+-- mkIConst :: (RealFloat a, Integral b) => b -> (b,LSLValue a)
+-- mkIConst i = (i,IVal i)
 
-cPrimHoleDefault = 0 :: Int
-cPrimHoleSquare = 32 :: Int
-cPrimHoleCircle = 16 :: Int
-cPrimHoleTriangle = 48 :: Int
+cPrimHoleDefault = 0 :: LSLInteger
+cPrimHoleSquare = 32 :: LSLInteger
+cPrimHoleCircle = 16 :: LSLInteger
+cPrimHoleTriangle = 48 :: LSLInteger
 validPrimHoleType = flip elem $ map IVal [cPrimHoleDefault,cPrimHoleSquare,
     cPrimHoleCircle,cPrimHoleTriangle]
 
@@ -794,7 +795,7 @@ allConstants = [
     Constant "TEXTURE_MEDIA" (KVal $ LSLKey "8b5fec65-8d8d-9dc5-cda8-8fdf2716e361"),
     Constant "TEXTURE_PLYWOOD" (KVal $ LSLKey "89556747-24cb-43ed-920b-47caed15465f"),
     Constant "TEXTURE_TRANSPARENT" (KVal $ LSLKey "8dcd4a48-2d37-4909-9f78-f7a9eb4ef903"),
-    Constant "TOUCH_INVALID_FACE" (IVal 0xffffffff),
+    Constant "TOUCH_INVALID_FACE" (IVal (-1)),
     Constant "TOUCH_INVALID_TEXCOORD" (VVal (-1) (-1) 0),
     Constant "TOUCH_INVALID_VECTOR" (VVal 0 0 0),
     Constant "TRAVERSAL_TYPE" (IVal 7),

--- a/lslforge/haskell/src/Language/Lsl/Internal/Evaluation.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/Evaluation.hs
@@ -6,17 +6,18 @@ module Language.Lsl.Internal.Evaluation(
 import Data.Map(Map)
 import Language.Lsl.Internal.Key(LSLKey(..))
 import Language.Lsl.Internal.Type(LSLValue)
+import Language.Lsl.Internal.Util(LSLInteger)
 import Language.Lsl.Internal.Breakpoint(Breakpoint)
 
 --type ScriptInfo = (String,Int,String,String) -- (object id, prim index, script name, prim key)
 data ScriptInfo a = ScriptInfo { scriptInfoObjectKey :: LSLKey,
-                                 scriptInfoPrimIndex :: Int,
+                                 scriptInfoPrimIndex :: LSLInteger,
                                  scriptInfoScriptName :: String,
                                  scriptInfoPrimKey :: LSLKey,
                                  scriptInfoCurrentEvent :: Maybe (Event a) }
     deriving (Show)
 
-data EvalResult = EvalIncomplete | EvalComplete (Maybe String) | YieldTil Int
+data EvalResult = EvalIncomplete | EvalComplete (Maybe String) | YieldTil LSLInteger
                 | BrokeAt Breakpoint
     deriving (Show)
 

--- a/lslforge/haskell/src/Language/Lsl/Internal/Exec.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/Exec.hs
@@ -42,14 +42,14 @@ import Language.Lsl.Internal.Breakpoint(Breakpoint(..),StepManager(..),
     pushStepManagerFrame,popStepManagerFrame,emptyStepManager,mkBreakpoint)
 import Language.Lsl.Internal.CodeHelper(renderCall)
 import Language.Lsl.Internal.FuncSigs(convertArgs)
-import Language.Lsl.Internal.Util(fromInt,lookupM,ctx,findM)
+import Language.Lsl.Internal.Util(LSLInteger,fromInt,lookupM,ctx,findM)
 import Language.Lsl.Syntax(
     Expr(..), CompiledLSLScript(..),Statement(..),Func(..),FuncDec(..),Var(..),
     State(..),Ctx(..),Global(..),TextLocation(..),SourceContext(..),
     Handler(..),ctxVr2Vr,findFunc,findFuncDec,ctxItems,findState,fromMCtx,
     predefFuncs)
 import Language.Lsl.Internal.Type(
-    LSLType(..),LSLValue(..),typeOfLSLComponent,typeOfLSLValue,toFloat,toSVal,
+    LSLType(..),LSLValue(..),iVal,typeOfLSLComponent,typeOfLSLValue,toFloat,toSVal,
     lslShowVal,replaceLslValueComponent,vecMulScalar,rotMulVec,parseVector,
     parseRotation,parseInt,parseFloat,invRot,rotMul,vcross,Component(..),
     lslValueComponent)
@@ -112,14 +112,14 @@ executeLsl img oid pid sid pkey perf log qtick utick chkBp queue maxTick =
 data EvalState m a = EvalState {
      scriptImage :: ScriptImage a,
      objectId :: LSLKey,
-     primId :: Int,
+     primId :: LSLInteger,
      scriptName :: String,
      myPrimKey :: LSLKey,
      performAction :: String -> ScriptInfo a -> [LSLValue a] ->
         m (EvalResult,LSLValue a),
      logMessage :: String -> m (),
-     qwtick :: m Int,
-     uwtick :: Int -> m (),
+     qwtick :: m LSLInteger,
+     uwtick :: LSLInteger -> m (),
      checkBreakpoint :: Breakpoint -> StepManager -> m (Bool, StepManager),
      nextEvent :: String -> String -> m (Maybe (Event a))  }
 
@@ -287,9 +287,9 @@ evalLit globals expr =
                 (IVal i) -> fromInteger $ toInteger i
                 _ -> error "invalid float expression"
     in case expr of
-        Neg (Ctx _ (IntLit i)) -> IVal (-i)
+        Neg (Ctx _ (IntLit i)) -> iVal $ (-i)
         Neg (Ctx _ (FloatLit f)) -> FVal (-(realToFrac f))
-        IntLit i        -> IVal i
+        IntLit i        -> iVal i
         FloatLit f      -> FVal (realToFrac f)
         StringLit s     -> SVal s
         KeyLit k        -> KVal $ LSLKey k
@@ -384,9 +384,9 @@ queryExState q = queryState (q . scriptImage)
 updateExState :: Monad w => (ScriptImage a -> ScriptImage a) -> Eval a w ()
 updateExState u = updateState (\s -> s { scriptImage = u $ scriptImage s })
 
-getTick :: Monad w => Eval a w Int
+getTick :: Monad w => Eval a w LSLInteger
 getTick = lift =<< qwtick <$> get
-setTick :: (Monad w) => Int -> Eval a w ()
+setTick :: (Monad w) => LSLInteger -> Eval a w ()
 setTick v = lift =<< (uwtick <$> get <*> pure v)
 
 doAction name scriptInfo args =
@@ -416,7 +416,7 @@ getCurState :: Monad w => Eval a w String
 getCurState = queryExState curState
 getObjectId :: Monad w => Eval a w LSLKey
 getObjectId = queryState objectId
-getPrimId :: Monad w => Eval a w Int
+getPrimId :: Monad w => Eval a w LSLInteger
 getPrimId = queryState primId
 getScriptName :: Monad w => Eval a w String
 getScriptName = queryState scriptName
@@ -578,8 +578,8 @@ modMark f = do
             setCallStack (frame { frameStacks = (sc':ss',es) }:frames)
 
 data ExecutionState =
-      Waiting | Executing | Halted | SleepingTil Int | Erroneous String
-    | Crashed String | Suspended Breakpoint | WaitingTil Int
+      Waiting | Executing | Halted | SleepingTil LSLInteger | Erroneous String
+    | Crashed String | Suspended Breakpoint | WaitingTil LSLInteger
     deriving (Show,Eq)
 
 matchEvent :: (RealFloat t) => Event t -> [Ctx Handler] ->
@@ -630,7 +630,7 @@ setupSimple path globbindings args = do
 
 incontext s f = either throwError return f
 
-evalScript :: (RealFloat a, Read a, Show a, Monad w) => Int -> [Event a] -> Eval a w [Event a]
+evalScript :: (RealFloat a, Read a, Show a, Monad w) => LSLInteger -> [Event a] -> Eval a w [Event a]
 evalScript maxTick queue = do
     executionState <- getExecutionState
     case executionState of
@@ -689,7 +689,7 @@ evalScript maxTick queue = do
                 else return queue
         Halted -> return queue
 
-eval :: (RealFloat a, Read a, Show a, Monad w) => Int -> Eval a w EvalResult
+eval :: (RealFloat a, Read a, Show a, Monad w) => LSLInteger -> Eval a w EvalResult
 eval maxTick =  do
        t <- (+1) <$> getTick
        setTick t
@@ -781,7 +781,7 @@ eval' =
                     val <- popVal
                     pushElement (EvCtxStatement (if trueCondition val then stmt1 else stmt2))
                     continue
-                EvExpr (IntLit i) -> pushVal (IVal i) >> continue
+                EvExpr (IntLit i) -> pushVal (iVal i) >> continue
                 EvExpr (FloatLit f) -> pushVal (FVal (realToFrac f)) >> continue
                 EvExpr (StringLit s) -> pushVal (SVal s) >> continue
                 EvExpr (KeyLit k) -> pushVal (KVal $ LSLKey k) >> continue
@@ -975,17 +975,17 @@ eval' =
                     (IVal i1,FVal f2) -> toLslBool $ fromInt i1 == f2
                     (v1,v2) -> toLslBool $ v1 == v2
                 EvNe -> evalBinary $ \ val1 val2 -> case (val1,val2) of
-                    (LVal l1, LVal l2) -> IVal (length l1 - length l2) -- special case of LSL weirdness
+                    (LVal l1, LVal l2) -> iVal (length l1 - length l2) -- special case of LSL weirdness
                     (SVal s, KVal k) -> toLslBool $ s /= unLslKey k
                     (KVal k, SVal s) -> toLslBool $ unLslKey k /= s
                     (FVal f1,IVal i2) -> toLslBool $ f1 /= fromInt i2
                     (IVal i1,FVal f2) -> toLslBool $ fromInt i1 /= f2
                     (v1,v2) -> toLslBool $ v1 /= v2
                 EvShiftL -> evalBinary $ \ val1 val2 -> case (val1,val2) of
-                    (IVal i1,IVal i2) -> IVal (i1 `shiftL` i2)
+                    (IVal i1,IVal i2) -> IVal (i1 `shiftL` (fromInt i2))
                     _ -> error ("cannot apply operator to " ++ (show val1) ++ " and " ++ (show val2))
                 EvShiftR -> evalBinary $ \ val1 val2 -> case (val1,val2) of
-                    (IVal i1,IVal i2) -> IVal (i1 `shiftR` i2)
+                    (IVal i1,IVal i2) -> IVal (i1 `shiftR` (fromInt i2))
                     _ -> error ("cannot apply operator to " ++ (show val1) ++ " and " ++ (show val2))
                 EvNot -> do
                     val <- popVal

--- a/lslforge/haskell/src/Language/Lsl/Internal/Exec.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/Exec.hs
@@ -30,6 +30,7 @@ module Language.Lsl.Internal.Exec(
 
 import Control.Monad(foldM_,when,mplus,msum,zipWithM,ap,liftM)
 import Control.Monad.Except(MonadError(..),ExceptT(..),runExceptT)
+import qualified Control.Monad.Fail as F
 import Control.Monad.State(MonadState(..),lift,StateT(..))
 import Control.Monad.Trans
 import Data.Bits((.&.),(.|.),xor,shiftL,shiftR,complement)
@@ -269,7 +270,7 @@ writeMem name value cells =
         (cells',[]) -> fail "no such variable"
         (xs,y:ys) -> return ((name,value):(xs ++ ys))
 
-readMem :: Monad m => String -> MemRegion a -> m (LSLValue a)
+readMem :: F.MonadFail m => String -> MemRegion a -> m (LSLValue a)
 readMem = lookupM
 
 initGlobals :: RealFloat a => [Global] -> MemRegion a

--- a/lslforge/haskell/src/Language/Lsl/Internal/ExpressionHandler.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/ExpressionHandler.hs
@@ -204,7 +204,7 @@ evalExpr (Not expr) =
     do t <- evalCtxExpr expr
        case t of
            (IVal i) -> return $ IVal (if i == 0 then 1 else 0)
-evalExpr (IntLit i) = return (IVal i)
+evalExpr (IntLit i) = return (iVal i)
 evalExpr (FloatLit f) = return (FVal $ realToFrac f)
 evalExpr (StringLit s) = return (SVal s)
 evalExpr (KeyLit k) = return (KVal $ LSLKey k)
@@ -333,7 +333,7 @@ evalRelExpr fi ff e0 e1 =
 
 evalIntExpr f e0 e1 =
     do (IVal i0, IVal i1) <- evalEach e0 e1
-       return $ IVal $ f i0 i1
+       return $ iVal $ f (fromInt i0) (fromInt i1)
 
 evalEach e0 e1 =
     do v0 <- evalCtxExpr e0

--- a/lslforge/haskell/src/Language/Lsl/Internal/Log.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/Log.hs
@@ -1,9 +1,11 @@
 module Language.Lsl.Internal.Log(LogLevel(..), LogMessage(..),logLevelToName) where
 
+import Language.Lsl.Internal.Util(LSLInteger)
+
 data LogLevel = LogTrace | LogDebug | LogInfo | LogWarn | LogError
     deriving (Show,Eq,Ord)
 
-data LogMessage = LogMessage { logMessageTime :: Int, logMessageLevel :: LogLevel,
+data LogMessage = LogMessage { logMessageTime :: LSLInteger, logMessageLevel :: LogLevel,
                                logMessageSource :: String, logMessageText :: String }
     deriving (Show)
 

--- a/lslforge/haskell/src/Language/Lsl/Internal/NumberParsing.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/NumberParsing.hs
@@ -47,11 +47,11 @@ doFloat = try hexFloatAndTail <|> (do
 hexInt =
     do oneOf "xX"
        digits <- many1 hexDigit
-       return $ foldl (\ x y -> x * 16 + y) 0 $ map digitToInt digits
+       return $ foldl (\ x y -> x * 16 + y) 0 $ map (fromIntegral . digitToInt) digits
 
 decimalInt =
     do digits <- many1 digit
-       return $ foldl (\ x y -> x * 10 + y) 0 $ map digitToInt digits
+       return $ foldl (\ x y -> x * 10 + y) 0 $ map (fromIntegral . digitToInt) digits
 
 int = do char '0'
          (hexInt <|> decimalInt <|> return 0)

--- a/lslforge/haskell/src/Language/Lsl/Internal/Optimize.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/Optimize.hs
@@ -22,9 +22,9 @@ import Language.Lsl.Internal.OptimizerOptions(OptimizerOption(..))
 import Language.Lsl.Syntax(CompiledLSLScript(..),Expr(..),Statement(..),Var(..),
                            Func(..),FuncDec(..),State(..),Ctx(..),Handler(..),
                            Global(..),Component(..),SourceContext(..),lslQ)
-import Language.Lsl.Internal.Type(LSLType(..),toSVal)
+import Language.Lsl.Internal.Type(LSLType(..),LSLValue(..),toSVal)
 import Language.Lsl.Internal.Pragmas(Pragma(..))
-import Language.Lsl.Internal.Type(LSLValue(..))
+import Language.Lsl.Internal.Util(LSLInteger,fromInt)
 import Language.Lsl.UnitTestEnv(simSFunc)
 
 optionInlining = elem OptimizationInlining
@@ -819,7 +819,7 @@ globalConstants gs fs ss =
           mexpr2expr m LLKey Nothing = KeyLit ""
           mexpr2expr m LLVoid Nothing = error "somehow, an expression of type void?"
 
-bb2int :: (a -> a -> Bool) -> a -> a -> Int
+bb2int :: (a -> a -> Bool) -> a -> a -> LSLInteger
 bb2int op x y = if op x y then 1 else 0
 
 fromBool :: Num a => Bool -> a
@@ -913,8 +913,8 @@ simplifyE (NotEqual (Ctx _ (IntLit i)) (Ctx _ (IntLit j)))  = return (IntLit (bb
 simplifyE (BAnd (Ctx _ (IntLit i)) (Ctx _ (IntLit j)))  = return (IntLit (i .&. j))
 simplifyE (BOr (Ctx _ (IntLit i)) (Ctx _ (IntLit j)))  = return (IntLit (i .|. j))
 simplifyE (Xor (Ctx _ (IntLit i)) (Ctx _ (IntLit j)))  = return (IntLit (i `xor` j))
-simplifyE (ShiftL (Ctx _ (IntLit i)) (Ctx _ (IntLit j)))  = return (IntLit (i `shiftL` j))
-simplifyE (ShiftR (Ctx _ (IntLit i)) (Ctx _ (IntLit j)))  = return (IntLit (i `shiftR` j))
+simplifyE (ShiftL (Ctx _ (IntLit i)) (Ctx _ (IntLit j)))  = return (IntLit (i `shiftL` fromInt j))
+simplifyE (ShiftR (Ctx _ (IntLit i)) (Ctx _ (IntLit j)))  = return (IntLit (i `shiftR` fromInt j))
 simplifyE e@(Div (Ctx _ (IntLit i)) (Ctx _ (IntLit j))) | j /= 0 = return (IntLit ( i `div` j))
                                                         | otherwise = return e
 simplifyE e@(Mod (Ctx _ (IntLit i)) (Ctx _ (IntLit j))) | j /= 0 = return (IntLit ( i `mod` j))

--- a/lslforge/haskell/src/Language/Lsl/Internal/SerializationGenerator.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/SerializationGenerator.hs
@@ -333,6 +333,7 @@ collectReps names = do
           decomposeType m ListT = return m
           decomposeType m (ConT nm) | nm == ''Bool ||
                                       nm == ''Int ||
+                                      nm == ''Int32 ||
                                       nm == ''Char ||
                                       nm == ''[] ||
                                       -- nm == ''Maybe ||

--- a/lslforge/haskell/src/Language/Lsl/Internal/TestResult.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/TestResult.hs
@@ -1,11 +1,12 @@
 module Language.Lsl.Internal.TestResult(TestResult(..),resultToXML, emitTestResult) where
 
 import Language.Lsl.Internal.XmlCreate(emit,emitSimple)
+import Language.Lsl.Internal.Util(LSLInteger)
 
-data TestResult = ErrorResult String String [(Int,String)] |
-                  FailureResult String String [(Int,String)] |
-                  Timeout String [(Int,String)] |
-                  SuccessResult String [(Int,String)]
+data TestResult = ErrorResult String String [(LSLInteger,String)] |
+                  FailureResult String String [(LSLInteger,String)] |
+                  Timeout String [(LSLInteger,String)] |
+                  SuccessResult String [(LSLInteger,String)]
     deriving Show
 
 okResult = 0

--- a/lslforge/haskell/src/Language/Lsl/Internal/Type.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/Type.hs
@@ -4,6 +4,7 @@ module Language.Lsl.Internal.Type(
     LSLType(..),
     LSLValue(..),
     Component(..),
+    iVal,
     convertValues,
     typeOfLSLValue,
     typeOfLSLComponent,
@@ -46,7 +47,7 @@ import Data.Data(Data,Typeable)
 import Data.List(intersperse)
 import Language.Lsl.Internal.NumberParsing(readInt,readHexFloat)
 import Language.Lsl.Internal.Key(nullKey,LSLKey(..))
-import Language.Lsl.Internal.Util(cross,quaternionMultiply,quaternionToMatrix,fromInt)
+import Language.Lsl.Internal.Util(LSLInteger,cross,quaternionMultiply,quaternionToMatrix,fromInt)
 import Language.Lsl.Internal.DOMProcessing(req,choicet,text,elist,val)
      --(Element(..),ElemAcceptor(..),findValue,elementsOnly,simple,attrString,acceptList)
 
@@ -57,9 +58,12 @@ data LSLType = LLList | LLInteger | LLVector | LLFloat | LLString | LLRot | LLKe
 
 -- A value.  Values correspond to the built in types (LSLType) that LSL
 -- supports.  A value is an item that can be pushed onto the value stack.
-data LSLValue a = IVal Int | FVal a | SVal String | VVal a a a
+data LSLValue a = IVal LSLInteger | FVal a | SVal String | VVal a a a
                | RVal a a a a | LVal [LSLValue a] | KVal LSLKey
                | VoidVal deriving (Show,Eq,Ord)
+
+iVal :: Integral a => a -> LSLValue b
+iVal = IVal . fromInt
 
 data Component = X | Y | Z | S | All deriving (Eq,Show, Typeable, Data)
 
@@ -167,7 +171,8 @@ isKVal _ = False
 parseInt s =
    case readInt s of
        [] -> 0
-       (i,_):_ -> i
+       (i,_):_ -> fromInt i
+
 parseFloat s =
    case readFloat s of
        [] -> 0.0

--- a/lslforge/haskell/src/Language/Lsl/Internal/Util.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/Util.hs
@@ -40,6 +40,7 @@ module Language.Lsl.Internal.Util (
 
 import Control.Monad(liftM,when,MonadPlus(..))
 import Control.Monad.Except(MonadError(..))
+import qualified Control.Monad.Fail as F
 import Data.Char
 import Data.Int(Int32)
 import Data.List(find,elemIndex,isPrefixOf,tails)
@@ -94,10 +95,10 @@ whenJust Nothing _ = return ()
 whenJust (Just v) action = action v
 
 -- monadified lookup
-lookupM :: (Monad m, Eq a, Show a) => a -> [(a,b)] -> m b
+lookupM :: (F.MonadFail m, Eq a, Show a) => a -> [(a,b)] -> m b
 lookupM x l =
    case lookup x l of
-       Nothing -> fail ((show x) ++ " not found")
+       Nothing -> F.fail ((show x) ++ " not found")
        Just y -> return y
 
 -- monadified find
@@ -122,7 +123,7 @@ filtMapM f (x:xs) =
             Nothing -> filtMapM f xs
             Just y -> liftM (y:) (filtMapM f xs)
 
-lookupByIndex :: (Integral a, Show a, Monad m) => a -> [b] -> m b
+lookupByIndex :: (Integral a, Show a, F.MonadFail m) => a -> [b] -> m b
 lookupByIndex i l = lookupM i $ zip [0..] l
 
 removeLookup :: Eq a => a -> [(a,b)] -> [(a,b)]

--- a/lslforge/haskell/src/Language/Lsl/Internal/Util.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/Util.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -fwarn-unused-binds -XNoMonomorphismRestriction -XFlexibleContexts #-}
 module Language.Lsl.Internal.Util (
+    LSLInteger,
     mlookup,
     ilookup,
     safeIndex,
@@ -40,6 +41,7 @@ module Language.Lsl.Internal.Util (
 import Control.Monad(liftM,when,MonadPlus(..))
 import Control.Monad.Except(MonadError(..))
 import Data.Char
+import Data.Int(Int32)
 import Data.List(find,elemIndex,isPrefixOf,tails)
 import qualified Data.ByteString.Lazy.Char8 as B
 import qualified Data.Map as Map
@@ -51,6 +53,8 @@ import Language.Lsl.Internal.Math
 
 import Network.URI(escapeURIString,isUnescapedInURI,unEscapeString)
 import System.IO(hFlush,stdout)
+
+type LSLInteger = Int32
 
 -- some random operators
 (<||>) a b = a `catchError` const b
@@ -118,7 +122,7 @@ filtMapM f (x:xs) =
             Nothing -> filtMapM f xs
             Just y -> liftM (y:) (filtMapM f xs)
 
-lookupByIndex :: Monad m => Int -> [a] -> m a
+lookupByIndex :: (Integral a, Show a, Monad m) => a -> [b] -> m b
 lookupByIndex i l = lookupM i $ zip [0..] l
 
 removeLookup :: Eq a => a -> [(a,b)] -> [(a,b)]
@@ -130,8 +134,8 @@ removeLookup k l = let (xs,ys) = break ((k==).fst) l in
 indexOf :: Eq a => [a] -> [a] -> Maybe Int
 indexOf sub list = elemIndex True $ map (isPrefixOf sub) (tails list)
 
-fromInt :: Num a => Int -> a
-fromInt = fromInteger . toInteger
+fromInt :: (Num a, Integral b) => b -> a
+fromInt = fromIntegral
 
 cut :: Int -> Int -> [a] -> ([a],[a])
 cut start end src = (take start src, drop end src)

--- a/lslforge/haskell/src/Language/Lsl/Internal/WorldState.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/WorldState.hs
@@ -95,7 +95,7 @@ import Language.Lsl.Internal.Exec(hasActiveHandler)
 import Language.Lsl.Internal.Key(mkKey,LSLKey(..),nullKey)
 import Language.Lsl.Internal.Log(LogMessage(..),LogLevel(..))
 import Language.Lsl.Internal.Type(LSLValue(..),vec2VVal)
-import Language.Lsl.Internal.Util(lookupByIndex)
+import Language.Lsl.Internal.Util(LSLInteger,fromInt,lookupByIndex)
 import Language.Lsl.WorldDef(Attachment,InventoryItem(..),InventoryItemIdentification(..),
     Region(..),Parcel(..),Prim,isInvNotecardItem,isInvLandmarkItem,
     isInvClothingItem,isInvBodyPartItem,isInvGestureItem,isInvSoundItem,
@@ -145,11 +145,11 @@ getPrimLinkNum pk = do
             links <- getM $ primKeys.lm ok.wobjects
             case elemIndex pk links of
                 Nothing -> throwError err
-                Just i -> return (i + 1)
+                Just i -> return (fromInt i + 1)
     where err = "internal error, can't find prim in link list of parent object"
 
 -- TODO: temp until introduce region into Prim definition
-getPrimRegion _ = return (0 :: Int, 0 :: Int)
+getPrimRegion _ = return (0 :: LSLInteger, 0 :: LSLInteger)
 
 getPos pkey = runErrPrim pkey (VVal 0.0 0.0 0.0)
     (vec2VVal <$> (getRootPrim pkey >>= getObjectPosition))
@@ -157,9 +157,9 @@ getPos pkey = runErrPrim pkey (VVal 0.0 0.0 0.0)
 runErrFace k i defaultVal = runAndLogIfErr
     ("face " ++ (show i) ++ " or prim " ++ unLslKey k ++ " not found") defaultVal
 
-getPrimFaceAlpha k i = getM (faceAlpha.lli i.primFaces.wprim k)
-getPrimFaceColor k i = getM (faceColor.lli i.primFaces.wprim k)
-getPrimFaceTextureInfo k i = getM (faceTextureInfo.lli i.primFaces.wprim k)
+getPrimFaceAlpha k i = getM (faceAlpha.lli (fromInt i).primFaces.wprim k)
+getPrimFaceColor k i = getM (faceColor.lli (fromInt i).primFaces.wprim k)
+getPrimFaceTextureInfo k i = getM (faceTextureInfo.lli (fromInt i).primFaces.wprim k)
 
 runErrPrim k defaultVal =
     runAndLogIfErr ("prim " ++ unLslKey k ++ " not found") defaultVal
@@ -176,7 +176,7 @@ setPrimFaceColor k i v = runErrFace k i () $ updatePrimFace k i (setI faceColor 
 isSensorEvent (SensorEvent {}) = True
 isSensorEvent _ = False
 
-takeWQ :: Int -> WorldEventQueue -> (Maybe WorldEventType,WorldEventQueue)
+takeWQ :: LSLInteger -> WorldEventQueue -> (Maybe WorldEventType,WorldEventQueue)
 takeWQ i [] = (Nothing,[])
 takeWQ i ((j,we):wes) | i >= j = (Just we,wes)
                       | otherwise = (Nothing,wes)

--- a/lslforge/haskell/src/Language/Lsl/Internal/WorldStateTypes.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/WorldStateTypes.hs
@@ -25,6 +25,7 @@ import Language.Lsl.Internal.Key(LSLKey(..))
 import Language.Lsl.Internal.Log(LogMessage(..))
 import Language.Lsl.Syntax(Validity,LModule(..),CompiledLSLScript(..))
 import Language.Lsl.Internal.Type(LSLValue(..),LSLType(..))
+import Language.Lsl.Internal.Util(LSLInteger)
 import Language.Lsl.WorldDef(Prim(..),PrimFace(..),InventoryItem(..),
     LSLObject(..),Script(..),Avatar(..),
     Region(..),ObjectDynamics(..),WebHandling(..),PrimType(..),
@@ -32,7 +33,7 @@ import Language.Lsl.WorldDef(Prim(..),PrimFace(..),InventoryItem(..),
 
 import System.Random(StdGen(..))
 
-type WorldEvent = (Int,WorldEventType) -- time, event
+type WorldEvent = (LSLInteger,WorldEventType) -- time, event
 
 type WorldEventQueue = [WorldEvent]
 
@@ -48,11 +49,11 @@ data WorldEventType =
             deferredScriptEvent :: Event Float,
             deferredScriptEventTarget :: DeferredScriptEventTarget }
         | Chat {
-            chatChannel :: Int,
+            chatChannel :: LSLInteger,
             chatterName :: String,
             chatterKey :: LSLKey,
             chatMessage :: String,
-            chatLocation :: ((Int,Int),(Float,Float,Float)),
+            chatLocation :: ((LSLInteger,LSLInteger),(Float,Float,Float)),
             chatRange :: Maybe Float }
         | TimerEvent {
             timerEventInterval :: Float,
@@ -61,19 +62,19 @@ data WorldEventType =
             permissionRequestPrim :: LSLKey,
             permissionRequestScript :: String,
             permissionRequestAgent :: LSLKey,
-            permissionRequestMask :: Int }
+            permissionRequestMask :: LSLInteger }
         | SensorEvent {
             sensorAddress :: (LSLKey,String),
             sensorSenseName :: String,
             sensorSenseKey :: LSLKey,
-            sensorSenseType :: Int,
+            sensorSenseType :: LSLInteger,
             sensorSenseRange :: Float,
             sensorSenseArc :: Float,
             sensorRepeat :: Maybe Float }
         | XMLRequestEvent {
             xmlRequestSource :: XMLRequestSourceType,
             xmlRequestChannel :: LSLKey,
-            xmlRequestIData :: Int,
+            xmlRequestIData :: LSLInteger,
             xmlRequestSData :: String }
         | HTTPRequestEvent {
             httpRequestSource :: (LSLKey,String),
@@ -81,27 +82,27 @@ data WorldEventType =
             httpRequestURL :: String,
             httpRequestMethod :: String,
             httpRequestMimetype :: String,
-            httpRequestBodyMaxlength :: Int,
-            httpRequestVerifyCert :: Int,
+            httpRequestBodyMaxlength :: LSLInteger,
+            httpRequestVerifyCert :: LSLInteger,
             httpRequestBody :: String }
         | XMLReplyEvent {
             xmlRequestKey :: LSLKey,
             xmlRequestChannel :: LSLKey,
             xmlRequestMessageId :: LSLKey,
             xmlRequestSData :: String,
-            xmlRequestIData :: Int }
+            xmlRequestIData :: LSLInteger }
         | DialogEvent {
             dialogAgent :: LSLKey,
             dialogMessage :: String,
             dialogButtons :: [String],
-            dialogChannel :: Int,
+            dialogChannel :: LSLInteger,
             dialogSourceObject :: LSLKey }
         | RezObjectEvent {
             rezObjectLinkSet :: [Prim],
             rezObjectPos :: (Float,Float,Float),
             rezObjectVel :: (Float,Float,Float),
             rezObjectRot :: (Float,Float,Float,Float),
-            rezObjectStartParam :: Int,
+            rezObjectStartParam :: LSLInteger,
             rezObjectRezzer :: LSLKey,
             rezObjectCopy :: Bool,
             rezObjectAtRoot :: Bool }
@@ -140,13 +141,13 @@ data DeferredScriptEventTarget =
 data Touch = Touch {
     touchAvatarKey :: LSLKey,
     touchPrimKey :: LSLKey,
-    touchFace :: Int,
+    touchFace :: LSLInteger,
     touchST :: (Float,Float),
-    touchStartTick :: Int,
-    touchEndTick :: Int  }
+    touchStartTick :: LSLInteger,
+    touchEndTick :: LSLInteger  }
     deriving (Show)
 
-data SimEvent = SimEvent { simEventName :: String, simEventArgs :: [SimEventArg], simEventDelay :: Int }
+data SimEvent = SimEvent { simEventName :: String, simEventArgs :: [SimEventArg], simEventDelay :: LSLInteger }
     deriving (Show)
 data SimEventArg = SimEventArg { simEventArgName :: String, simEventArgValue :: String }
     deriving (Show)
@@ -154,7 +155,7 @@ data SimEventArg = SimEventArg { simEventArgName :: String, simEventArgValue :: 
 data Listener = Listener {
     listenerPrimKey :: LSLKey,
     listenerScriptName :: String,
-    listenerChannel :: Int,
+    listenerChannel :: LSLInteger,
     listenerName :: String,
     listenerKey :: LSLKey,
     listenerMsg :: String }
@@ -201,22 +202,22 @@ data PendingHTTPResponse = PendingHTTPResponse {
         phrQuery :: String,
         phrRemoteIP :: String,
         phrUserAgent :: String,
-        phrExpire :: Int
+        phrExpire :: LSLInteger
     } deriving (Show)
 
 -- a data type that defines the state of the 'world'
 data World m = World {
-        _sliceSize :: !Int,
-        _maxTick :: !Int,
-        _nextPause :: !Int,
+        _sliceSize :: !LSLInteger,
+        _maxTick :: !LSLInteger,
+        _nextPause :: !LSLInteger,
         _wqueue :: !WorldEventQueue,
         _wlisteners :: !(IM.IntMap (Listener,Bool)),
-        _nextListenerId :: !Int,
+        _nextListenerId :: !LSLInteger,
         _wobjects :: !(Map LSLKey LSLObject),
         _wprims :: !(Map LSLKey Prim),
         _worldScripts :: !(Map (LSLKey,String) Script),
         _inventory :: ![(String,LSLObject)],
-        _tick :: !Int,
+        _tick :: !LSLInteger,
         _msglog :: ![LogMessage],
         _predefs :: !(Map String (PredefFunc m)),
         _randGen :: !StdGen,
@@ -226,21 +227,21 @@ data World m = World {
         _worldAvatars :: !(Map LSLKey Avatar),
         _worldBreakpointManager :: !BreakpointManager,
         _worldSuspended :: !(Maybe (LSLKey,String)), -- prim-key, script-name, image
-        _worldRegions :: !(Map (Int,Int) Region),
-        _worldZeroTime :: !Int,
+        _worldRegions :: !(Map (LSLInteger,LSLInteger) Region),
+        _worldZeroTime :: !LSLInteger,
         _worldKeyIndex :: !Integer,
         _worldWebHandling :: !WebHandling,
         _worldOutputQueue :: ![SimEvent],
         _worldPendingHTTPRequests :: ![LSLKey],
         _worldOpenDataChannels :: !(Map LSLKey (LSLKey,String),Map (LSLKey,String) LSLKey),
         _worldXMLRequestRegistry :: !(Map LSLKey XMLRequestSourceType),
-        _worldPhysicsTime :: !Int,
-        _worldTargetCheckTime :: !Int,
+        _worldPhysicsTime :: !LSLInteger,
+        _worldTargetCheckTime :: !LSLInteger,
         _worldLastPositions :: !(Map LSLKey (Bool,(Float,Float,Float))),
         _worldCollisions :: !(S.Set (LSLKey,LSLKey)),
         _worldLandCollisions :: !(S.Set LSLKey),
         _worldTouches :: !(Map LSLKey [Touch]),
-        _worldTouchCheckTime :: !Int,
+        _worldTouchCheckTime :: !LSLInteger,
         _worldURLRegistry :: !(Map String (LSLKey,ScriptId)),
         _worldPendingHTTPResponses :: !(Map LSLKey PendingHTTPResponse)
     } deriving (Show)

--- a/lslforge/haskell/src/Language/Lsl/Internal/WorldStateTypes.hs
+++ b/lslforge/haskell/src/Language/Lsl/Internal/WorldStateTypes.hs
@@ -11,6 +11,8 @@ module Language.Lsl.Internal.WorldStateTypes where
 import Control.Applicative
 import Control.Monad(liftM,ap,MonadPlus(..))
 import Control.Monad.Except(ExceptT(..),MonadError(..))
+import qualified Control.Monad.Fail as F
+import Control.Monad.Outdated.Error(Error(..))
 import Control.Monad.State(MonadState(..),StateT(..))
 import Data.Map(Map)
 import qualified Data.IntMap as IM
@@ -193,6 +195,9 @@ instance Monad m => Applicative (WorldE m) where
 instance Monad m => Alternative (WorldE m) where
    empty = mzero
    (<|>) = mplus
+
+instance Monad m => F.MonadFail (WorldE m) where
+    fail e = WorldE $ ExceptT $ return (Left $ strMsg e)
 
 data PendingHTTPResponse = PendingHTTPResponse {
         phrRequesterKey :: LSLKey,

--- a/lslforge/haskell/src/Language/Lsl/Syntax.hs
+++ b/lslforge/haskell/src/Language/Lsl/Syntax.hs
@@ -68,7 +68,7 @@ import Data.Maybe(isJust,isNothing)
 import Language.Lsl.Internal.Util(LSLInteger,ctx,findM,lookupM,filtMap)
 import Control.Monad(when,MonadPlus(..))
 import Control.Monad.Except(MonadError(..))
--- import Control.Monad.Error.Class(Error(..))
+import Control.Monad.Outdated.Error(Error(..))
 import qualified Control.Monad.State as S(State)
 import Control.Monad.State hiding(State)
 
@@ -256,6 +256,10 @@ msgFromCodeErr = snd
 
 -- | An error monad for representing validation errors with respect to LSL code.
 type Validity a = Either CodeErrs a
+
+instance Error CodeErrs where
+    noMsg = CodeErrs [(Nothing,"")]
+    strMsg s = CodeErrs [(Nothing,s)]
 
 --------------------
 

--- a/lslforge/haskell/src/Language/Lsl/Syntax.hs
+++ b/lslforge/haskell/src/Language/Lsl/Syntax.hs
@@ -65,7 +65,7 @@ import Data.Data(Data,Typeable)
 import Data.List(find,sort,sortBy,nub,nubBy,deleteFirstsBy)
 import qualified Data.Map as M
 import Data.Maybe(isJust,isNothing)
-import Language.Lsl.Internal.Util(ctx,findM,lookupM,filtMap)
+import Language.Lsl.Internal.Util(LSLInteger,ctx,findM,lookupM,filtMap)
 import Control.Monad(when,MonadPlus(..))
 import Control.Monad.Except(MonadError(..))
 -- import Control.Monad.Error.Class(Error(..))
@@ -132,7 +132,7 @@ data LModule = LModule [GlobDef] [CtxVar]
 
 type CtxExpr = Ctx Expr
 -- | An LSL expression.
-data Expr = IntLit Int
+data Expr = IntLit LSLInteger
           | FloatLit Double
           | StringLit String
           | ListExpr [CtxExpr]

--- a/lslforge/haskell/src/Language/Lsl/UnitTestEnv.hs
+++ b/lslforge/haskell/src/Language/Lsl/UnitTestEnv.hs
@@ -37,14 +37,14 @@ import Language.Lsl.Internal.TestResult(TestResult(..))
 import Language.Lsl.UnitTest(
     EntryPoint(..),LSLUnitTest(..),ExpectationMode(..),
     FuncCallExpectations(..),expectedReturns,removeExpectation)
-import Language.Lsl.Internal.Util(findM,ctx)
+import Language.Lsl.Internal.Util(LSLInteger,findM,ctx)
 
 --trace1 v = trace ("->>" ++ (show v)) v
 
 data SimpleWorld a = SimpleWorld {
-        maxTick :: Int,
-        tick :: Int,
-        msgLog :: [(Int,String)],
+        maxTick :: LSLInteger,
+        tick :: LSLInteger,
+        msgLog :: [(LSLInteger,String)],
         wScripts :: [(String,Validity CompiledLSLScript)],
         wLibrary :: [(String,Validity LModule)],
         expectations :: FuncCallExpectations a,
@@ -52,11 +52,11 @@ data SimpleWorld a = SimpleWorld {
     }
 
 type SimpleWorldM a = ExceptT String (State (SimpleWorld a))
-getTick :: SimpleWorldM a Int
+getTick :: SimpleWorldM a LSLInteger
 getTick = get >>= return . tick
-getMaxTick :: SimpleWorldM a Int
+getMaxTick :: SimpleWorldM a LSLInteger
 getMaxTick = get >>= return . maxTick
-getMsgLog :: SimpleWorldM a [(Int,String)]
+getMsgLog :: SimpleWorldM a [(LSLInteger,String)]
 getMsgLog = get >>= return . msgLog
 getWScripts :: SimpleWorldM a [(String, Validity CompiledLSLScript)]
 getWScripts = get >>= return . wScripts

--- a/lslforge/haskell/src/Language/Lsl/WorldDef.hs
+++ b/lslforge/haskell/src/Language/Lsl/WorldDef.hs
@@ -84,19 +84,19 @@ import Language.Lsl.Internal.Exec(ScriptImage,initLSLScript)
 import Language.Lsl.Internal.Key(mkKey,nullKey,LSLKey(..))
 import Language.Lsl.Internal.Type(LSLValue(..))
 import Language.Lsl.Internal.Util(
-    mlookup,Permutation3(..),rotationsToQuaternion)
+    mlookup,Permutation3(..),rotationsToQuaternion,LSLInteger)
 
 type ScriptId = (LSLKey,String)
 
 data FullWorldDef = FullWorldDef {
-    fullWorldDefMaxTime :: Int,
-    fullWorldDefSliceSize :: Int,
+    fullWorldDefMaxTime :: LSLInteger,
+    fullWorldDefSliceSize :: LSLInteger,
     fullWorldDefWebHandling :: WebHandling,
     fullWorldDefEventHandler :: Maybe String,
     fullWorldDefObjects :: [LSLObject],
     fullWorldDefPrims :: [Prim],
     fullWorldDefAvatars :: [Avatar],
-    fullWorldDefRegions :: [((Int,Int),Region)],
+    fullWorldDefRegions :: [((LSLInteger,LSLInteger),Region)],
     fullWorldDefInitialKeyIndex :: Integer } deriving (Show)
 
 data WebHandling =
@@ -114,9 +114,9 @@ data ObjectDynamics = ObjectDynamics {
     _objectVelocity :: (Float,Float,Float),
     _objectForce :: ((Float,Float,Float),Bool),
     _objectBuoyancy :: Float,
-    _objectImpulse :: (((Float,Float,Float),Bool),Int),
+    _objectImpulse :: (((Float,Float,Float),Bool),LSLInteger),
     _objectTorque :: ((Float,Float,Float),Bool),
-    _objectRotationalImpulse :: (((Float,Float,Float),Bool),Int),
+    _objectRotationalImpulse :: (((Float,Float,Float),Bool),LSLInteger),
     _objectOmega :: (Float,Float,Float),
     _objectPositionTarget :: !(Maybe PositionTarget),
     _objectRotationTarget :: !(Maybe RotationTarget),
@@ -160,23 +160,23 @@ data Avatar = Avatar {
     _avatarKey :: LSLKey,
     _avatarName :: String,
     _avatarActiveGroup :: Maybe LSLKey,
-    _avatarRegion :: (Int,Int),
+    _avatarRegion :: (LSLInteger,LSLInteger),
     _avatarPosition :: (Float,Float,Float),
     _avatarRotation :: (Float,Float,Float,Float),
     _avatarHeight :: Float,
-    _avatarState :: Int,
+    _avatarState :: LSLInteger,
     _avatarInventory :: [InventoryItem],
     _avatarCameraPosition :: (Float,Float,Float),
     _avatarCameraRotation :: (Float,Float,Float,Float),
     _avatarCameraControlParams :: CameraParams,
-    _avatarActiveAnimations :: [(Maybe Int,LSLKey)],
+    _avatarActiveAnimations :: [(Maybe LSLInteger,LSLKey)],
     _avatarAttachments :: IM.IntMap LSLKey,
     _avatarEventHandler :: !(Maybe (String,[(String,LSLValue Float)])),
-    _avatarControls :: !Int,
+    _avatarControls :: !LSLInteger,
     _avatarControlListener :: !(Maybe AvatarControlListener) } deriving (Show)
 
 data AvatarControlListener = AvatarControlListener {
-    avatarControlListenerMask :: !Int,
+    avatarControlListenerMask :: !LSLInteger,
     avatarControlListenerScript :: !(LSLKey,String) } deriving (Show)
 
 data CameraParams = CameraParams {
@@ -230,9 +230,9 @@ defaultAvatar key = Avatar {
         _avatarControlListener = Nothing }
 
 -- these are bit INDEXES not MASKS (0 == least significant bit)
-primPhantomBit :: Int
+primPhantomBit :: LSLInteger
 primPhantomBit = 4
-primPhysicsBit :: Int
+primPhysicsBit :: LSLInteger
 primPhysicsBit = 0
 
 data InventoryItemData =
@@ -243,7 +243,7 @@ data InventoryItemData =
     | InvTexture
     | InvSound { invSoundDuration :: Float }
     | InvAnimation { invAnimationDuration :: Maybe Float }
-    | InvLandmark { invLandmarkLocation :: ((Int,Int),(Float,Float,Float)) }
+    | InvLandmark { invLandmarkLocation :: ((LSLInteger,LSLInteger),(Float,Float,Float)) }
     | InvNotecard { invNotecardLines :: [String] }
     | InvObject { invObjectPrims :: [Prim] } deriving (Show)
 
@@ -290,11 +290,11 @@ data InventoryItem = InventoryItem {
     inventoryItemData :: InventoryItemData } deriving (Show)
 
 data ItemPermissions = ItemPermissions {
-        permMaskBase :: Int,
-        permMaskOwner :: Int,
-        permMaskGroup :: Int,
-        permMaskEveryone :: Int,
-        permMaskNext :: Int
+        permMaskBase :: LSLInteger,
+        permMaskOwner :: LSLInteger,
+        permMaskGroup :: LSLInteger,
+        permMaskEveryone :: LSLInteger,
+        permMaskNext :: LSLInteger
     } deriving Show
 
 inventoryItemName = fst . inventoryItemNameKey . inventoryItemIdentification
@@ -317,7 +317,7 @@ inventoryInfoPermValue i =
     const (throwError ("no such perm mask - " ++ show i))
 
 defaultInventoryPermissions =
-    ItemPermissions 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+    ItemPermissions (-1) (-1) (-1) (-1) (-1)
 
 data Prim = Prim {
     _primName :: String,
@@ -333,28 +333,28 @@ data Prim = Prim {
     _primScale :: (Float, Float, Float),
     _primFaces :: [PrimFace],
     _primFlexibility :: Maybe Flexibility,
-    _primMaterial :: Int,
-    _primStatus :: Int,
-    _primVehicleFlags :: Int,
+    _primMaterial :: LSLInteger,
+    _primStatus :: LSLInteger,
+    _primVehicleFlags :: LSLInteger,
     _primLight :: Maybe LightInfo,
     _primTempOnRez :: Bool,
     _primTypeInfo :: PrimType,
-    _primPermissions :: [Int],
+    _primPermissions :: [LSLInteger],
     _primAllowInventoryDrop :: Bool,
     _primSitTarget :: Maybe ((Float,Float,Float),(Float,Float,Float,Float)),
     _primSittingAvatar :: Maybe LSLKey,
     _primPendingEmails :: [Email],
     _primPassTouches :: Bool,
     _primPassCollisions :: Bool,
-    _primPayInfo :: (Int,Int,Int,Int,Int),
+    _primPayInfo :: (LSLInteger,LSLInteger,LSLInteger,LSLInteger,LSLInteger),
     _primAttachment :: Maybe Attachment,
-    _primRemoteScriptAccessPin :: Int } deriving (Show)
+    _primRemoteScriptAccessPin :: LSLInteger } deriving (Show)
 
 data PrimType =
     PrimType {
-       _primVersion :: Int, -- 1 or 9
-       _primTypeCode :: Int,
-       _primHoleshape :: Int,
+       _primVersion :: LSLInteger, -- 1 or 9
+       _primTypeCode :: LSLInteger,
+       _primHoleshape :: LSLInteger,
        _primCut :: (Float,Float,Float),
        _primTwist :: (Float,Float,Float),
        _primHolesize :: (Float,Float,Float),
@@ -366,14 +366,14 @@ data PrimType =
        _primRevolutions :: Float,
        _primSkew :: Float,
        _primSculptTexture :: Maybe String,
-       _primSculptType :: Int
+       _primSculptType :: LSLInteger
     } deriving (Show)
 
 basicBox = PrimType 9 0 0 (0,1,0) (0,0,0) (0,0,0) (0,0,0) 0 (0,0,0) (0,1,0) 0 0 0 Nothing 0
 
 data Attachment = Attachment {
     _attachmentKey :: LSLKey,
-    _attachmentPoint :: Int } deriving (Show)
+    _attachmentPoint :: LSLInteger } deriving (Show)
 
 data LightInfo = LightInfo {
     _lightColor :: (Float,Float,Float),
@@ -383,7 +383,7 @@ data LightInfo = LightInfo {
     } deriving (Show)
 
 data Flexibility = Flexibility {
-    _flexSoftness :: Int,
+    _flexSoftness :: LSLInteger,
     _flexGravity :: Float,
     _flexFriction :: Float,
     _flexWind :: Float,
@@ -394,10 +394,10 @@ data Flexibility = Flexibility {
 data PrimFace = PrimFace {
     _faceAlpha :: Float,
     _faceColor :: (Float,Float,Float),
-    _faceShininess :: Int,
-    _faceBumpiness :: Int,
+    _faceShininess :: LSLInteger,
+    _faceBumpiness :: LSLInteger,
     _faceFullbright :: Bool,
-    _faceTextureMode :: Int,
+    _faceTextureMode :: LSLInteger,
     _faceTextureInfo :: TextureInfo
     } deriving (Show)
 
@@ -416,7 +416,7 @@ data Email = Email {
     emailSubject :: String,
     emailAddress :: String, -- sender address
     emailMessage :: String,
-    emailTime :: Int } deriving (Show)
+    emailTime :: LSLInteger } deriving (Show)
 
 emptyPrim name key = Prim {
     _primName = name,
@@ -451,21 +451,21 @@ emptyPrim name key = Prim {
 
 data Region = Region {
     regionName :: String,
-    regionFlags :: Int,
+    regionFlags :: LSLInteger,
     regionParcels :: [Parcel]
     } deriving (Show)
 
 data Parcel = Parcel {
     parcelName :: String,
     parcelDescription :: String,
-    parcelBoundaries :: (Int,Int,Int,Int), -- bottom, top, left, right aka south,north,west,east
+    parcelBoundaries :: (LSLInteger,LSLInteger,LSLInteger,LSLInteger), -- bottom, top, left, right aka south,north,west,east
     parcelOwner :: LSLKey,
-    parcelFlags :: Int,
-    parcelBanList :: [(LSLKey,Maybe Int)],
-    parcelPassList :: [(LSLKey,Maybe Int)]
+    parcelFlags :: LSLInteger,
+    parcelBanList :: [(LSLKey,Maybe LSLInteger)],
+    parcelPassList :: [(LSLKey,Maybe LSLInteger)]
     } deriving (Show)
 
-defaultRegions :: LSLKey -> [((Int,Int),Region)]
+defaultRegions :: LSLKey -> [((LSLInteger,LSLInteger),Region)]
 defaultRegions owner =
     [(
         (0,0),
@@ -473,20 +473,20 @@ defaultRegions owner =
             regionName = "Region_0_0", regionFlags = 0,
             regionParcels =
                 [Parcel "parcel_0" "default parcel" (0,256,0,256) owner
-                    0xffffffff [] []] }
+                    (-1) [] []] }
     )]
 
 data Script = Script {
     _scriptImage :: !(ScriptImage Float),
     _scriptActive :: Bool,
-    _scriptPermissions :: M.Map LSLKey Int,
+    _scriptPermissions :: M.Map LSLKey LSLInteger,
     _scriptLastPerm :: Maybe LSLKey,
-    _scriptStartTick :: Int,
-    _scriptLastResetTick :: Int,
+    _scriptStartTick :: LSLInteger,
+    _scriptLastResetTick :: LSLInteger,
     _scriptEventQueue :: [Event Float],
-    _scriptStartParameter :: Int,
+    _scriptStartParameter :: LSLInteger,
     _scriptCollisionFilter :: !(String,LSLKey,Bool),
-    _scriptTargetIndex :: !Int,
+    _scriptTargetIndex :: !LSLInteger,
     _scriptPositionTargets :: !(IM.IntMap ((Float,Float,Float), Float)),
     _scriptRotationTargets :: !(IM.IntMap ((Float,Float,Float,Float), Float)),
     _scriptControls :: ![LSLKey] } deriving (Show)


### PR DESCRIPTION
It was the long and winding road but I finally did it!
This pull request contains 5 commits:

1. Changes to copy_mac.sh shell script for 64bit binary
2. Adaptation to 64bit Haskell because macOS only have 64bit Haskell. I don't know it works on 32bit Haskell
3. Tuple2/3 problem caused by change to Haskell abstract syntax tree(AST) used by functions depending on Template Haskell
4. Fix to llEscapeURL/llUnescapeURL at optimize/debug time caused by changes to library('escapeURIChar')
5. Fix to error exit of LSLForge process caused by changes to 'fail' method for 'Either' monad.

I didn't check SIM/Unit tester functions I usually didn't use.
Try it, but I'm not sure I can fix next bugs.
