### PR TITLE
Updating shell script for Mac

### DIFF
--- a/lslforge/copy_mac.sh
+++ b/lslforge/copy_mac.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
-strip haskell/.stack-work/install/x86_64-osx/lts-8.2/8.0.2/bin/LSLForge
-cp haskell/.stack-work/install/x86_64-osx/lts-8.2/8.0.2/bin/LSLForge eclipse/lslforge-macos-x86_64/os/macos/x86_64
+(cd haskell;stack install)
+strip ~/.local/bin/LSLForge
+cp ~/.local/bin/LSLForge eclipse/lslforge-macos-x86_64/os/macos/x86_64


### PR DESCRIPTION
New version of stack changed director of binary file.
So I need to update copy_mac.sh shell script
(I don't know it needs on other platform)
to copy it to local bin directory and stript symbols
from it.
Use this script after build (stack build) like this:
(cd ..;sh copy_mac.sh)